### PR TITLE
seperate context munging into new method

### DIFF
--- a/fullstory-segment-middleware/src/main/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddleware.java
+++ b/fullstory-segment-middleware/src/main/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddleware.java
@@ -135,12 +135,14 @@ public class FullStorySegmentMiddleware implements Middleware {
     }
 
     void addFSUrlToContext(Map<String, Object> context){
+        if(context == null) return null;
         // now URL API available post FullStory plugin v1.3.0
         // context.put("fullstoryUrl", FS.getCurrentSessionURL(true));
         context.put("fullstoryUrl", FS.getCurrentSessionURL());
     }
 
     BasePayload getNewPayloadWithFSURL(BasePayload payload, Map<String, Object> context) {
+        if(payload == null) return null;
         // properties obj is immutable so we need to create a new one
         ValueMap properties = payload.getValueMap("properties");
         Map<String, Object> fullStoryProperties = new HashMap<>();

--- a/fullstory-segment-middleware/src/main/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddleware.java
+++ b/fullstory-segment-middleware/src/main/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddleware.java
@@ -135,10 +135,11 @@ public class FullStorySegmentMiddleware implements Middleware {
     }
 
     void addFSUrlToContext(Map<String, Object> context){
-        if(context == null) return null;
-        // now URL API available post FullStory plugin v1.3.0
-        // context.put("fullstoryUrl", FS.getCurrentSessionURL(true));
-        context.put("fullstoryUrl", FS.getCurrentSessionURL());
+        if(context != null) {
+            // now URL API available post FullStory plugin v1.3.0
+            // context.put("fullstoryUrl", FS.getCurrentSessionURL(true));
+            context.put("fullstoryUrl", FS.getCurrentSessionURL());
+        }
     }
 
     BasePayload getNewPayloadWithFSURL(BasePayload payload, Map<String, Object> context) {

--- a/fullstory-segment-middleware/src/main/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddleware.java
+++ b/fullstory-segment-middleware/src/main/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddleware.java
@@ -126,11 +126,18 @@ public class FullStorySegmentMiddleware implements Middleware {
         // if enabled you will receive at your destination events with FS URL added
         Map<String, Object> context = new LinkedHashMap<>(payload.context());
         if (this.enableFSSessionURLInEvents) {
+            addFSUrlToContext(context);
             newPayload = getNewPayloadWithFSURL(payload, context);
         }
 
         if (newPayload == null) newPayload = payload.toBuilder().context(context).build();
         chain.proceed(newPayload);
+    }
+
+    void addFSUrlToContext(Map<String, Object> context){
+        // now URL API available post FullStory plugin v1.3.0
+        // context.put("fullstoryUrl", FS.getCurrentSessionURL(true));
+        context.put("fullstoryUrl", FS.getCurrentSessionURL());
     }
 
     BasePayload getNewPayloadWithFSURL(BasePayload payload, Map<String, Object> context) {
@@ -142,7 +149,6 @@ public class FullStorySegmentMiddleware implements Middleware {
         fullStoryProperties.put("fullstoryUrl", FS.getCurrentSessionURL());
         // now URL API available post FullStory plugin v1.3.0
         // fullStoryProperties.put("fullstoryNowUrl", FS.getCurrentSessionURL(true));
-        context.put("fullstoryUrl", FS.getCurrentSessionURL());
 
         if (payload.type() == BasePayload.Type.screen) {
             ScreenPayload screenPayload = (ScreenPayload) payload;


### PR DESCRIPTION
move context modification out of `getNewPayloadWithFSURL` to make the method name clearer and more testable