### PR TITLE
Sabrina/fssm test cases

### DIFF
--- a/fullstory-segment-middleware/build.gradle
+++ b/fullstory-segment-middleware/build.gradle
@@ -13,6 +13,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            testCoverageEnabled true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
@@ -41,7 +44,11 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'org.mockito:mockito-core:2.27.0'
-}
+
+    testImplementation 'org.powermock:powermock-core:2.0.2'
+    testImplementation 'org.powermock:powermock-module-junit4:2.0.2'
+    testImplementation 'org.powermock:powermock-api-mockito2:2.0.2'
+   }
 
 configurations {
     testImplementation.extendsFrom compileOnly

--- a/fullstory-segment-middleware/src/main/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddleware.java
+++ b/fullstory-segment-middleware/src/main/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddleware.java
@@ -27,7 +27,7 @@ public class FullStorySegmentMiddleware implements Middleware {
     public boolean enableFSSessionURLInEvents = true;
     public boolean enableSendScreenAsEvents = false;
     public boolean allowlistAllTrackEvents = false;
-    private ArrayList<String> allowlistedEvents;
+    ArrayList<String> allowlistedEvents;
 
 
     private final String TAG = "FullStoryMiddleware";

--- a/fullstory-segment-middleware/src/main/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddleware.java
+++ b/fullstory-segment-middleware/src/main/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddleware.java
@@ -27,7 +27,7 @@ public class FullStorySegmentMiddleware implements Middleware {
     public boolean enableFSSessionURLInEvents = true;
     public boolean enableSendScreenAsEvents = false;
     public boolean allowlistAllTrackEvents = false;
-    ArrayList<String> allowlistedEvents;
+    private ArrayList<String> allowlistedEvents;
 
 
     private final String TAG = "FullStoryMiddleware";

--- a/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FSSuffixedPropertiesTest.java
+++ b/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FSSuffixedPropertiesTest.java
@@ -262,6 +262,14 @@ public class FSSuffixedPropertiesTest {
         Assert.assertEquals(output, fsSuffixedProperties.suffixedProperties);
     }
 
+    @Test
+    public void getSuffixedProperties_ReturnsProperties() {
+        Map<String, Object> input = new HashMap<>();
+        input.put("key_strs", new ArrayList<>(Arrays.asList("val1","val2")));
+        fsSuffixedProperties.suffixedProperties = input;
+        Assert.assertEquals(input, fsSuffixedProperties.getSuffixedProperties());
+    }
+
     // Test for constructor with Segment E Commerce Events
     @Test
     public void constructor_ECommerceEventsProductsSearched() {

--- a/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
+++ b/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
@@ -63,7 +63,7 @@ public class FullStorySegmentMiddlewareTest {
     }
 
     @Test
-    public void constructor_WithAllowListedEvent() {
+    public void constructor_WithAllowListedEvent_AssertAllowList() {
         ArrayList<String> allowList = new ArrayList<>();
         allowList.add("Product Added");
         fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey", allowList);
@@ -72,7 +72,7 @@ public class FullStorySegmentMiddlewareTest {
     }
 
     @Test
-    public void constructor_NoAllowListedEvent() {
+    public void constructor_NoAllowListedEvent_AssertDefaultValues() {
         fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         Assert.assertTrue(fullStorySegmentMiddleware.enableFSSessionURLInEvents);
         Assert.assertFalse(fullStorySegmentMiddleware.enableGroupTraitsAsUserVars);
@@ -127,6 +127,7 @@ public class FullStorySegmentMiddlewareTest {
                 .build();
         when(mockChain.payload()).thenReturn(groupPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
+
         // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(groupPayload);
     }
@@ -183,6 +184,7 @@ public class FullStorySegmentMiddlewareTest {
                 .build();
         when(mockChain.payload()).thenReturn(identifyPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
+
         // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(identifyPayload);
     }
@@ -218,6 +220,7 @@ public class FullStorySegmentMiddlewareTest {
                 .build();
         when(mockChain.payload()).thenReturn(screenPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
+
         // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(screenPayload);
     }
@@ -253,6 +256,7 @@ public class FullStorySegmentMiddlewareTest {
                 .build();
         when(mockChain.payload()).thenReturn(screenPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
+
         // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(screenPayload);
     }
@@ -285,6 +289,7 @@ public class FullStorySegmentMiddlewareTest {
                 .build();
         when(mockChain.payload()).thenReturn(screenPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
+
         // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(screenPayload);
     }
@@ -318,6 +323,7 @@ public class FullStorySegmentMiddlewareTest {
         TrackPayload trackPayload = new TrackPayload.Builder().userId("userId").event("Product Added").build();
         when(mockChain.payload()).thenReturn(trackPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
+
         // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(trackPayload);
     }
@@ -346,6 +352,7 @@ public class FullStorySegmentMiddlewareTest {
         TrackPayload trackPayload = new TrackPayload.Builder().userId("userId").event("event").build();
         when(mockChain.payload()).thenReturn(trackPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
+
         // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(trackPayload);
     }
@@ -359,6 +366,7 @@ public class FullStorySegmentMiddlewareTest {
         AliasPayload aliasPayload = new AliasPayload.Builder().previousId("previousId").userId("userId").build();
         when(mockChain.payload()).thenReturn(aliasPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
+
         // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(aliasPayload);
     }
@@ -381,6 +389,7 @@ public class FullStorySegmentMiddlewareTest {
                 .context(newContext)
                 .properties(newProperties)
                 .build();
+
         // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(newTrackPayload);
     }
@@ -393,6 +402,7 @@ public class FullStorySegmentMiddlewareTest {
 
         Map<String, Object> expect = new HashMap<>();
         expect.put("fullstoryUrl", FS.getCurrentSessionURL());
+
         Assert.assertEquals(expect, input);
     }
 
@@ -415,6 +425,7 @@ public class FullStorySegmentMiddlewareTest {
 
         Properties expect = new Properties();
         expect.put("fullstoryUrl", FS.getCurrentSessionURL());
+
         Assert.assertEquals(output.properties(), expect);
     }
 
@@ -438,6 +449,7 @@ public class FullStorySegmentMiddlewareTest {
 
         Properties expect = new Properties();
         expect.put("fullstoryUrl", FS.getCurrentSessionURL());
+        
         Assert.assertEquals(output.properties(), expect);
     }
 }

--- a/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
+++ b/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
@@ -106,7 +106,7 @@ public class FullStorySegmentMiddlewareTest {
 
         // FS.event is called with properties
         Map<String, String> userVars = new HashMap<>();
-        userVars.put("groupID", groupPayload.groupId());
+        userVars.put("groupID_str", groupPayload.groupId());
         verifyStatic(FS.class, VerificationModeFactory.times(1));
         FS.setUserVars(userVars);
     }
@@ -146,9 +146,11 @@ public class FullStorySegmentMiddlewareTest {
         fullStorySegmentMiddleware.intercept(mockChain);
 
         // FS.event is called with properties
-        map.put("groupID", groupPayload.groupId());
+        Map<String, String> suffixedMap = new HashMap<>();
+        suffixedMap.put("groupID_str", groupPayload.groupId());
+        suffixedMap.put("industry_str", "retail");
         verifyStatic(FS.class, VerificationModeFactory.times(1));
-        FS.setUserVars(map);
+        FS.setUserVars(suffixedMap);
     }
 
     @Test
@@ -164,7 +166,7 @@ public class FullStorySegmentMiddlewareTest {
 
         // FS.event is called with properties
         verifyStatic(FS.class, VerificationModeFactory.times(1));
-        FS.identify(identifyPayload.userId(), null);
+        FS.identify(identifyPayload.userId(), new HashMap<>());
     }
 
     @Test

--- a/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
+++ b/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
@@ -91,7 +91,7 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(groupPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // chain.proceed is called with the correct payload
+        // verify that we did not block chain.proceed, nor modified the correct payload
         verify(mockChain, times(1)).proceed(groupPayload);
     }
 
@@ -104,10 +104,12 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(groupPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // FS.event is called with properties
+        // verify that static method setUserVars is called with the correct vars
         Map<String, String> userVars = new HashMap<>();
         userVars.put("groupID_str", groupPayload.groupId());
         verifyStatic(FS.class, VerificationModeFactory.times(1));
+        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.setUserVars(userVars);
     }
 
@@ -126,7 +128,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(groupPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // chain.proceed is called with the correct payload
         verify(mockChain, times(1)).proceed(groupPayload);
     }
 
@@ -145,7 +146,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(groupPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // FS.event is called with properties
         Map<String, String> suffixedMap = new HashMap<>();
         suffixedMap.put("groupID_str", groupPayload.groupId());
         suffixedMap.put("industry_str", "retail");
@@ -164,7 +164,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(identifyPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // FS.event is called with properties
         verifyStatic(FS.class, VerificationModeFactory.times(1));
         FS.identify(identifyPayload.userId(), new HashMap<>());
     }
@@ -180,7 +179,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(identifyPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // chain.proceed is called with the correct payload
         verify(mockChain, times(1)).proceed(identifyPayload);
     }
 
@@ -197,7 +195,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(screenPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // FS.event is called with properties
         verifyStatic(FS.class, VerificationModeFactory.times(1));
         FS.event("Segment Screen: " + screenPayload.name(), screenPayload.properties());
     }
@@ -215,7 +212,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(screenPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // chain.proceed is called with the correct payload
         verify(mockChain, times(1)).proceed(screenPayload);
     }
 
@@ -232,7 +228,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(screenPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // FS.event is called with properties
         verifyStatic(FS.class, VerificationModeFactory.times(0));
         FS.event(any(), any());
     }
@@ -250,7 +245,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(screenPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // chain.proceed is called with the correct payload
         verify(mockChain, times(1)).proceed(screenPayload);
     }
 
@@ -264,7 +258,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(trackPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // FS.event is called with properties
         verifyStatic(FS.class, VerificationModeFactory.times(0));
         FS.event(any(),any());
     }
@@ -282,7 +275,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(screenPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // chain.proceed is called with the correct payload
         verify(mockChain, times(1)).proceed(screenPayload);
     }
 
@@ -298,7 +290,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(trackPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // FS.event is called with properties
         verifyStatic(FS.class, VerificationModeFactory.times(1));
         FS.event(trackPayload.event(), trackPayload.properties());
     }
@@ -315,7 +306,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(trackPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // chain.proceed is called with the correct payload
         verify(mockChain, times(1)).proceed(trackPayload);
     }
 
@@ -328,7 +318,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(trackPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // FS.event is called with properties
         verifyStatic(FS.class, VerificationModeFactory.times(1));
         FS.event(trackPayload.event(), trackPayload.properties());
     }
@@ -343,7 +332,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(trackPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // chain.proceed is called with the correct payload
         verify(mockChain, times(1)).proceed(trackPayload);
     }
 
@@ -357,7 +345,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(aliasPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // chain.proceed is called with the correct payload
         verify(mockChain, times(1)).proceed(aliasPayload);
     }
 
@@ -370,7 +357,6 @@ public class FullStorySegmentMiddlewareTest {
         when(mockChain.payload()).thenReturn(inputTrackPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // chain.proceed is called with the correct payload
         Map<String, Object> newContext = new HashMap<>(inputTrackPayload.context());
         newContext.put("fullstoryUrl", FS.getCurrentSessionURL());
         Map<String, Object> newProperties = new HashMap<>(inputTrackPayload.properties());

--- a/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
+++ b/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
@@ -84,20 +84,20 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_GroupPayloadChain_DisableGroupTraitsAsUserVars_ChainProceedCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "FakeSegmentWriteKey");
         fullStorySegmentMiddleware.enableGroupTraitsAsUserVars = false;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
         GroupPayload groupPayload = new GroupPayload.Builder().userId("userId").groupId("groupId").build();
         when(mockChain.payload()).thenReturn(groupPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
 
-        // verify that we did not block chain.proceed, nor modified the correct payload
+        // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(groupPayload);
     }
 
     @Test
     public void intercept_GroupPayloadChain_DisableGroupTraitsAsUserVars_FSSetUserVarsCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "FakeSegmentWriteKey");
         fullStorySegmentMiddleware.enableGroupTraitsAsUserVars = false;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
         GroupPayload groupPayload = new GroupPayload.Builder().userId("userId").groupId("groupId").build();
@@ -127,7 +127,7 @@ public class FullStorySegmentMiddlewareTest {
                 .build();
         when(mockChain.payload()).thenReturn(groupPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
-
+        // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(groupPayload);
     }
 
@@ -149,7 +149,10 @@ public class FullStorySegmentMiddlewareTest {
         Map<String, String> suffixedMap = new HashMap<>();
         suffixedMap.put("groupID_str", groupPayload.groupId());
         suffixedMap.put("industry_str", "retail");
+
         verifyStatic(FS.class, VerificationModeFactory.times(1));
+        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.setUserVars(suffixedMap);
     }
 
@@ -165,6 +168,8 @@ public class FullStorySegmentMiddlewareTest {
         fullStorySegmentMiddleware.intercept(mockChain);
 
         verifyStatic(FS.class, VerificationModeFactory.times(1));
+        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.identify(identifyPayload.userId(), new HashMap<>());
     }
 
@@ -178,7 +183,7 @@ public class FullStorySegmentMiddlewareTest {
                 .build();
         when(mockChain.payload()).thenReturn(identifyPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
-
+        // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(identifyPayload);
     }
 
@@ -196,6 +201,8 @@ public class FullStorySegmentMiddlewareTest {
         fullStorySegmentMiddleware.intercept(mockChain);
 
         verifyStatic(FS.class, VerificationModeFactory.times(1));
+        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.event("Segment Screen: " + screenPayload.name(), screenPayload.properties());
     }
 
@@ -211,7 +218,7 @@ public class FullStorySegmentMiddlewareTest {
                 .build();
         when(mockChain.payload()).thenReturn(screenPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
-
+        // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(screenPayload);
     }
 
@@ -229,6 +236,8 @@ public class FullStorySegmentMiddlewareTest {
         fullStorySegmentMiddleware.intercept(mockChain);
 
         verifyStatic(FS.class, VerificationModeFactory.times(0));
+        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.event(any(), any());
     }
 
@@ -244,7 +253,7 @@ public class FullStorySegmentMiddlewareTest {
                 .build();
         when(mockChain.payload()).thenReturn(screenPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
-
+        // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(screenPayload);
     }
 
@@ -259,6 +268,8 @@ public class FullStorySegmentMiddlewareTest {
         fullStorySegmentMiddleware.intercept(mockChain);
 
         verifyStatic(FS.class, VerificationModeFactory.times(0));
+        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.event(any(),any());
     }
 
@@ -274,7 +285,7 @@ public class FullStorySegmentMiddlewareTest {
                 .build();
         when(mockChain.payload()).thenReturn(screenPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
-
+        // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(screenPayload);
     }
 
@@ -291,6 +302,8 @@ public class FullStorySegmentMiddlewareTest {
         fullStorySegmentMiddleware.intercept(mockChain);
 
         verifyStatic(FS.class, VerificationModeFactory.times(1));
+        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.event(trackPayload.event(), trackPayload.properties());
     }
 
@@ -305,7 +318,7 @@ public class FullStorySegmentMiddlewareTest {
         TrackPayload trackPayload = new TrackPayload.Builder().userId("userId").event("Product Added").build();
         when(mockChain.payload()).thenReturn(trackPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
-
+        // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(trackPayload);
     }
 
@@ -319,6 +332,8 @@ public class FullStorySegmentMiddlewareTest {
         fullStorySegmentMiddleware.intercept(mockChain);
 
         verifyStatic(FS.class, VerificationModeFactory.times(1));
+        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.event(trackPayload.event(), trackPayload.properties());
     }
 
@@ -331,7 +346,7 @@ public class FullStorySegmentMiddlewareTest {
         TrackPayload trackPayload = new TrackPayload.Builder().userId("userId").event("event").build();
         when(mockChain.payload()).thenReturn(trackPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
-
+        // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(trackPayload);
     }
 
@@ -344,7 +359,7 @@ public class FullStorySegmentMiddlewareTest {
         AliasPayload aliasPayload = new AliasPayload.Builder().previousId("previousId").userId("userId").build();
         when(mockChain.payload()).thenReturn(aliasPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
-
+        // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(aliasPayload);
     }
 
@@ -366,7 +381,7 @@ public class FullStorySegmentMiddlewareTest {
                 .context(newContext)
                 .properties(newProperties)
                 .build();
-
+        // verify that we did not block chain.proceed, nor modified the payload
         verify(mockChain, times(1)).proceed(newTrackPayload);
     }
 

--- a/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
+++ b/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
@@ -27,6 +27,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -42,7 +43,6 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({FS.class, Log.class})
 public class FullStorySegmentMiddlewareTest {
-
     @Mock
     Context mockContext;
     @Mock
@@ -50,11 +50,10 @@ public class FullStorySegmentMiddlewareTest {
     @Mock
     Middleware.Chain mockChain;
 
-    FullStorySegmentMiddleware fullStorySegmentMiddleware;
-
     @Before
     public void setUp(){
         MockitoAnnotations.initMocks(this);
+
         when(mockContext.getSharedPreferences(anyString(), anyInt())).thenReturn(mockPrefs);
 
         PowerMockito.mockStatic(FS.class);
@@ -64,29 +63,32 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void constructor_WithAllowListedEvent_AssertAllowList() {
-        ArrayList<String> allowList = new ArrayList<>();
+        List<String> allowList = new ArrayList<>();
         allowList.add("Product Added");
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey", allowList);
-        Assert.assertEquals(allowList, fullStorySegmentMiddleware.allowlistedEvents);
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey", allowList);
+
+        Assert.assertEquals("Testing allowlistedEvents",allowList, fullStorySegmentMiddleware.allowlistedEvents);
         // TODO: assert logging for SharedPreferences listener code
     }
 
     @Test
     public void constructor_NoAllowListedEvent_AssertDefaultValues() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
-        Assert.assertTrue(fullStorySegmentMiddleware.enableFSSessionURLInEvents);
-        Assert.assertFalse(fullStorySegmentMiddleware.enableGroupTraitsAsUserVars);
-        Assert.assertFalse(fullStorySegmentMiddleware.enableSendScreenAsEvents);
-        Assert.assertFalse(fullStorySegmentMiddleware.allowlistAllTrackEvents);
-        Assert.assertTrue(fullStorySegmentMiddleware.allowlistedEvents.isEmpty());
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+
+        Assert.assertTrue("Testing enableFSSessionURLInEvents", fullStorySegmentMiddleware.enableFSSessionURLInEvents);
+        Assert.assertFalse("Testing enableGroupTraitsAsUserVars", fullStorySegmentMiddleware.enableGroupTraitsAsUserVars);
+        Assert.assertFalse("Testing enableSendScreenAsEvents", fullStorySegmentMiddleware.enableSendScreenAsEvents);
+        Assert.assertFalse("Testing allowlistAllTrackEvents", fullStorySegmentMiddleware.allowlistAllTrackEvents);
+        Assert.assertTrue("Testing allowlistedEvents", fullStorySegmentMiddleware.allowlistedEvents.isEmpty());
         // TODO: assert logging for null allowlist warning
     }
 
     @Test
     public void intercept_GroupPayloadChain_DisableGroupTraitsAsUserVars_ChainProceedCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "FakeSegmentWriteKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "FakeSegmentWriteKey");
         fullStorySegmentMiddleware.enableGroupTraitsAsUserVars = false;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
         GroupPayload groupPayload = new GroupPayload.Builder().userId("userId").groupId("groupId").build();
         when(mockChain.payload()).thenReturn(groupPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
@@ -97,9 +99,10 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_GroupPayloadChain_DisableGroupTraitsAsUserVars_FSSetUserVarsCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "FakeSegmentWriteKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "FakeSegmentWriteKey");
         fullStorySegmentMiddleware.enableGroupTraitsAsUserVars = false;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
         GroupPayload groupPayload = new GroupPayload.Builder().userId("userId").groupId("groupId").build();
         when(mockChain.payload()).thenReturn(groupPayload);
         fullStorySegmentMiddleware.intercept(mockChain);
@@ -115,9 +118,10 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_GroupPayloadChain_EnableGroupTraitsAsUserVars_ChainProceedCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.enableGroupTraitsAsUserVars = true;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
         Map<String, String> map = new HashMap<>();
         map.put("industry", "retail");
         GroupPayload groupPayload = new GroupPayload.Builder()
@@ -134,9 +138,10 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_GroupPayloadChain_EnableGroupTraitsAsUserVars_FSSetUserVarsCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.enableGroupTraitsAsUserVars = true;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
         Map<String, String> map = new HashMap<>();
         map.put("industry", "retail");
         GroupPayload groupPayload = new GroupPayload.Builder()
@@ -159,7 +164,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_IdentifyPayloadChain_NoTraits_FSIdentifyCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
 
         IdentifyPayload identifyPayload = new IdentifyPayload.Builder()
@@ -176,7 +181,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_IdentifyPayloadChain_UserTraits_ChainProceedCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
 
         IdentifyPayload identifyPayload = new IdentifyPayload.Builder()
@@ -191,7 +196,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_ScreenPayloadChain_EnableSendScreenAsEvents_FSEventCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.enableSendScreenAsEvents = true;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
 
@@ -210,7 +215,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_ScreenPayloadChain_EnableSendScreenAsEvents_ChainProceedCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.enableSendScreenAsEvents = true;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
 
@@ -227,7 +232,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_ScreenPayloadChain_DisableSendScreenAsEvents_FSEventNotCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.enableSendScreenAsEvents = false;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
 
@@ -246,7 +251,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_ScreenPayloadChain_DisableSendScreenAsEvents_ChainProceedCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.enableSendScreenAsEvents = false;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
 
@@ -263,7 +268,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_TrackPayloadChain_DisallowlistAllTrackEvents_NoAllowlistedEvents_FSEventNotCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.allowlistAllTrackEvents = false;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
 
@@ -279,7 +284,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_TrackPayloadChain_DisllowlistAllTrackEvents_NoAllowlistedEvents_ChainProceedCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.allowlistAllTrackEvents = false;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
 
@@ -298,7 +303,7 @@ public class FullStorySegmentMiddlewareTest {
     public void intercept_TrackPayloadChain_DisallowlistAllTrackEvents_EventAllowlisted_FSEventCalled() {
         ArrayList<String> allowList = new ArrayList<>();
         allowList.add("Product Added");
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey", allowList);
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey", allowList);
         fullStorySegmentMiddleware.allowlistAllTrackEvents = false;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
 
@@ -316,7 +321,7 @@ public class FullStorySegmentMiddlewareTest {
     public void intercept_TrackPayloadChain_DisllowlistAllTrackEvents_AllowlistedEvents_ChainProceedCalled() {
         ArrayList<String> allowList = new ArrayList<>();
         allowList.add("Product Added");
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey", allowList);
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey", allowList);
         fullStorySegmentMiddleware.allowlistAllTrackEvents = false;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
 
@@ -330,7 +335,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_TrackPayloadChain_AllowlistAllTrackEvents_FSEventCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.allowlistAllTrackEvents = true;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
         TrackPayload trackPayload = new TrackPayload.Builder().userId("userId").event("event").build();
@@ -345,7 +350,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_TrackPayloadChain_AllowlistAllTrackEvents_ChainProceedCalled() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.allowlistAllTrackEvents = true;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
 
@@ -359,7 +364,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_AliasPayload_DefaultCase() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.allowlistAllTrackEvents = true;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
 
@@ -373,7 +378,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void intercept_EnableFSSessionURLInEvents_VerifyChainProceed() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = true;
 
         TrackPayload inputTrackPayload = new TrackPayload.Builder().userId("userId").event("event").build();
@@ -396,7 +401,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void addFSUrlToContext_AddsURLToContext() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         Map<String, Object> input = new HashMap<>();
         fullStorySegmentMiddleware.addFSUrlToContext(input);
 
@@ -408,7 +413,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void getNewPayloadWithFSURL_TrackPayload_ReturnsTrackPayload() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         Map<String, Object> context = new HashMap<>();
         TrackPayload input = new TrackPayload.Builder().userId("userId").event("event").build();
         BasePayload output = fullStorySegmentMiddleware.getNewPayloadWithFSURL(input,context);
@@ -418,7 +423,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void getNewPayloadWithFSURL_TrackPayload_ReturnsTrackPayloadWithFSURL() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         Map<String, Object> context = new HashMap<>();
         TrackPayload input = new TrackPayload.Builder().userId("userId").event("event").build();
         TrackPayload output = (TrackPayload) fullStorySegmentMiddleware.getNewPayloadWithFSURL(input,context);
@@ -432,7 +437,7 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void getNewPayloadWithFSURL_ScreenPayload_ReturnsScreenPayload() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         Map<String, Object> context = new HashMap<>();
         ScreenPayload input = new ScreenPayload.Builder().userId("userId").name("MainActivity").build();
         BasePayload output = fullStorySegmentMiddleware.getNewPayloadWithFSURL(input,context);
@@ -442,14 +447,14 @@ public class FullStorySegmentMiddlewareTest {
 
     @Test
     public void getNewPayloadWithFSURL_ScreenPayload_ReturnsScreenPayloadWithFSURL() {
-        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        FullStorySegmentMiddleware fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         Map<String, Object> context = new HashMap<>();
         ScreenPayload input = new ScreenPayload.Builder().userId("userId").name("MainActivity").build();
         ScreenPayload output = (ScreenPayload) fullStorySegmentMiddleware.getNewPayloadWithFSURL(input,context);
 
         Properties expect = new Properties();
         expect.put("fullstoryUrl", FS.getCurrentSessionURL());
-        
+
         Assert.assertEquals(output.properties(), expect);
     }
 }

--- a/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
+++ b/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
@@ -1,0 +1,440 @@
+package com.fullstorydev.fullstory_segment_middleware;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import com.fullstory.FS;
+import com.segment.analytics.Middleware;
+import com.segment.analytics.integrations.AliasPayload;
+import com.segment.analytics.integrations.BasePayload;
+import com.segment.analytics.integrations.GroupPayload;
+import com.segment.analytics.integrations.IdentifyPayload;
+import com.segment.analytics.integrations.ScreenPayload;
+import com.segment.analytics.integrations.TrackPayload;
+import com.segment.analytics.Properties;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.internal.verification.VerificationModeFactory;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({FS.class, Log.class})
+public class FullStorySegmentMiddlewareTest {
+
+    @Mock
+    Context mockContext;
+    @Mock
+    SharedPreferences mockPrefs;
+    @Mock
+    Middleware.Chain mockChain;
+
+    FullStorySegmentMiddleware fullStorySegmentMiddleware;
+
+    @Before
+    public void setUp(){
+        MockitoAnnotations.initMocks(this);
+        when(mockContext.getSharedPreferences(anyString(), anyInt())).thenReturn(mockPrefs);
+
+        PowerMockito.mockStatic(FS.class);
+        when(FS.getCurrentSessionURL(anyBoolean())).thenReturn("mock FullStory Session URL");
+        when(FS.getCurrentSessionURL()).thenReturn("mock FullStory Session URL");
+    }
+
+    @Test
+    public void constructor_WithAllowListedEvent() {
+        ArrayList<String> allowList = new ArrayList<>();
+        allowList.add("Product Added");
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey", allowList);
+        Assert.assertEquals(allowList, fullStorySegmentMiddleware.allowlistedEvents);
+        // TODO: assert logging for SharedPreferences listener code
+    }
+
+    @Test
+    public void constructor_NoAllowListedEvent() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        Assert.assertTrue(fullStorySegmentMiddleware.enableFSSessionURLInEvents);
+        Assert.assertFalse(fullStorySegmentMiddleware.enableGroupTraitsAsUserVars);
+        Assert.assertFalse(fullStorySegmentMiddleware.enableSendScreenAsEvents);
+        Assert.assertFalse(fullStorySegmentMiddleware.allowlistAllTrackEvents);
+        Assert.assertTrue(fullStorySegmentMiddleware.allowlistedEvents.isEmpty());
+        // TODO: assert logging for null allowlist warning
+    }
+
+    @Test
+    public void intercept_GroupPayloadChain_DisableGroupTraitsAsUserVars_ChainProceedCalled() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.enableGroupTraitsAsUserVars = false;
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+        GroupPayload groupPayload = new GroupPayload.Builder().userId("userId").groupId("groupId").build();
+        when(mockChain.payload()).thenReturn(groupPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // chain.proceed is called with the correct payload
+        verify(mockChain, times(1)).proceed(groupPayload);
+    }
+
+    @Test
+    public void intercept_GroupPayloadChain_DisableGroupTraitsAsUserVars_FSSetUserVarsCalled() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.enableGroupTraitsAsUserVars = false;
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+        GroupPayload groupPayload = new GroupPayload.Builder().userId("userId").groupId("groupId").build();
+        when(mockChain.payload()).thenReturn(groupPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // FS.event is called with properties
+        Map<String, String> userVars = new HashMap<>();
+        userVars.put("groupID", groupPayload.groupId());
+        verifyStatic(FS.class, VerificationModeFactory.times(1));
+        FS.setUserVars(userVars);
+    }
+
+    @Test
+    public void intercept_GroupPayloadChain_EnableGroupTraitsAsUserVars_ChainProceedCalled() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.enableGroupTraitsAsUserVars = true;
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+        Map<String, String> map = new HashMap<>();
+        map.put("industry", "retail");
+        GroupPayload groupPayload = new GroupPayload.Builder()
+                .userId("userId")
+                .groupId("groupId")
+                .traits(map)
+                .build();
+        when(mockChain.payload()).thenReturn(groupPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // chain.proceed is called with the correct payload
+        verify(mockChain, times(1)).proceed(groupPayload);
+    }
+
+    @Test
+    public void intercept_GroupPayloadChain_EnableGroupTraitsAsUserVars_FSSetUserVarsCalled() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.enableGroupTraitsAsUserVars = true;
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+        Map<String, String> map = new HashMap<>();
+        map.put("industry", "retail");
+        GroupPayload groupPayload = new GroupPayload.Builder()
+                .userId("userId")
+                .groupId("groupId")
+                .traits(map)
+                .build();
+        when(mockChain.payload()).thenReturn(groupPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // FS.event is called with properties
+        map.put("groupID", groupPayload.groupId());
+        verifyStatic(FS.class, VerificationModeFactory.times(1));
+        FS.setUserVars(map);
+    }
+
+    @Test
+    public void intercept_IdentifyPayloadChain_NoTraits_FSIdentifyCalled() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
+        IdentifyPayload identifyPayload = new IdentifyPayload.Builder()
+                .userId("userId")
+                .build();
+        when(mockChain.payload()).thenReturn(identifyPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // FS.event is called with properties
+        verifyStatic(FS.class, VerificationModeFactory.times(1));
+        FS.identify(identifyPayload.userId(), null);
+    }
+
+    @Test
+    public void intercept_IdentifykPayloadChain_UserTraits_ChainProceedCalled() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
+        IdentifyPayload identifyPayload = new IdentifyPayload.Builder()
+                .userId("userId")
+                .build();
+        when(mockChain.payload()).thenReturn(identifyPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // chain.proceed is called with the correct payload
+        verify(mockChain, times(1)).proceed(identifyPayload);
+    }
+
+    @Test
+    public void intercept_ScreenPayloadChain_EnableSendScreenAsEvents_FSEventCalled() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.enableSendScreenAsEvents = true;
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
+        ScreenPayload screenPayload = new ScreenPayload.Builder()
+                .userId("userId")
+                .name("MainActivity")
+                .build();
+        when(mockChain.payload()).thenReturn(screenPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // FS.event is called with properties
+        verifyStatic(FS.class, VerificationModeFactory.times(1));
+        FS.event("Segment Screen: " + screenPayload.name(), screenPayload.properties());
+    }
+
+    @Test
+    public void intercept_ScreenPayloadChain_EnableSendScreenAsEvents_ChainProceedCalled() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.enableSendScreenAsEvents = true;
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
+        ScreenPayload screenPayload = new ScreenPayload.Builder()
+                .userId("userId")
+                .name("MainActivity")
+                .build();
+        when(mockChain.payload()).thenReturn(screenPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // chain.proceed is called with the correct payload
+        verify(mockChain, times(1)).proceed(screenPayload);
+    }
+
+    @Test
+    public void intercept_ScreenPayloadChain_EnableSendScreenAsEvents_FSEventNotCalled() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.enableSendScreenAsEvents = false;
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
+        ScreenPayload screenPayload = new ScreenPayload.Builder()
+                .userId("userId")
+                .name("MainActivity")
+                .build();
+        when(mockChain.payload()).thenReturn(screenPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // FS.event is called with properties
+        verifyStatic(FS.class, VerificationModeFactory.times(0));
+        FS.event(any(), any());
+    }
+
+    @Test
+    public void intercept_ScreenPayloadChain_DisableSendScreenAsEvents_ChainProceedCalled() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.enableSendScreenAsEvents = false;
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
+        ScreenPayload screenPayload = new ScreenPayload.Builder()
+                .userId("userId")
+                .name("MainActivity")
+                .build();
+        when(mockChain.payload()).thenReturn(screenPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // chain.proceed is called with the correct payload
+        verify(mockChain, times(1)).proceed(screenPayload);
+    }
+
+    @Test
+    public void intercept_TrackPayloadChain_DisallowlistAllTrackEvents_NoAllowlistedEvents_FSEventNotCalled() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.allowlistAllTrackEvents = false;
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
+        TrackPayload trackPayload = new TrackPayload.Builder().userId("userId").event("event").build();
+        when(mockChain.payload()).thenReturn(trackPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // FS.event is called with properties
+        verifyStatic(FS.class, VerificationModeFactory.times(0));
+        FS.event(any(),any());
+    }
+
+    @Test
+    public void intercept_TrackPayloadChain_DisllowlistAllTrackEvents_NoAllowlistedEvents_ChainProceedCalled() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.allowlistAllTrackEvents = false;
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
+        ScreenPayload screenPayload = new ScreenPayload.Builder()
+                .userId("userId")
+                .name("MainActivity")
+                .build();
+        when(mockChain.payload()).thenReturn(screenPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // chain.proceed is called with the correct payload
+        verify(mockChain, times(1)).proceed(screenPayload);
+    }
+
+    @Test
+    public void intercept_TrackPayloadChain_DisallowlistAllTrackEvents_EventAllowlisted_FSEventCalled() {
+        ArrayList<String> allowList = new ArrayList<>();
+        allowList.add("Product Added");
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey", allowList);
+        fullStorySegmentMiddleware.allowlistAllTrackEvents = false;
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
+        TrackPayload trackPayload = new TrackPayload.Builder().userId("userId").event("Product Added").build();
+        when(mockChain.payload()).thenReturn(trackPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // FS.event is called with properties
+        verifyStatic(FS.class, VerificationModeFactory.times(1));
+        FS.event(trackPayload.event(), trackPayload.properties());
+    }
+
+    @Test
+    public void intercept_TrackPayloadChain_DisllowlistAllTrackEvents_AllowlistedEvents_ChainProceedCalled() {
+        ArrayList<String> allowList = new ArrayList<>();
+        allowList.add("Product Added");
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey", allowList);
+        fullStorySegmentMiddleware.allowlistAllTrackEvents = false;
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
+        TrackPayload trackPayload = new TrackPayload.Builder().userId("userId").event("Product Added").build();
+        when(mockChain.payload()).thenReturn(trackPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // chain.proceed is called with the correct payload
+        verify(mockChain, times(1)).proceed(trackPayload);
+    }
+
+    @Test
+    public void intercept_TrackPayloadChain_AllowlistAllTrackEvents_FSEventCalled() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.allowlistAllTrackEvents = true;
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+        TrackPayload trackPayload = new TrackPayload.Builder().userId("userId").event("event").build();
+        when(mockChain.payload()).thenReturn(trackPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // FS.event is called with properties
+        verifyStatic(FS.class, VerificationModeFactory.times(1));
+        FS.event(trackPayload.event(), trackPayload.properties());
+    }
+
+    @Test
+    public void intercept_TrackPayloadChain_AllowlistAllTrackEvents_ChainProceedCalled() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.allowlistAllTrackEvents = true;
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
+        TrackPayload trackPayload = new TrackPayload.Builder().userId("userId").event("event").build();
+        when(mockChain.payload()).thenReturn(trackPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // chain.proceed is called with the correct payload
+        verify(mockChain, times(1)).proceed(trackPayload);
+    }
+
+    @Test
+    public void intercept_AliasPayload_DefaultCase() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.allowlistAllTrackEvents = true;
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
+
+        AliasPayload aliasPayload = new AliasPayload.Builder().previousId("previousId").userId("userId").build();
+        when(mockChain.payload()).thenReturn(aliasPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // chain.proceed is called with the correct payload
+        verify(mockChain, times(1)).proceed(aliasPayload);
+    }
+
+    @Test
+    public void intercept_EnableFSSessionURLInEvents_VerifyChainProceed() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        fullStorySegmentMiddleware.enableFSSessionURLInEvents = true;
+
+        TrackPayload inputTrackPayload = new TrackPayload.Builder().userId("userId").event("event").build();
+        when(mockChain.payload()).thenReturn(inputTrackPayload);
+        fullStorySegmentMiddleware.intercept(mockChain);
+
+        // chain.proceed is called with the correct payload
+        Map<String, Object> newContext = new HashMap<>(inputTrackPayload.context());
+        newContext.put("fullstoryUrl", FS.getCurrentSessionURL());
+        Map<String, Object> newProperties = new HashMap<>(inputTrackPayload.properties());
+        newProperties.put("fullstoryUrl", FS.getCurrentSessionURL());
+
+        TrackPayload newTrackPayload = inputTrackPayload.toBuilder()
+                .context(newContext)
+                .properties(newProperties)
+                .build();
+
+        verify(mockChain, times(1)).proceed(newTrackPayload);
+    }
+
+    @Test
+    public void addFSUrlToContext_AddsURLToContext() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        Map<String, Object> input = new HashMap<>();
+        fullStorySegmentMiddleware.addFSUrlToContext(input);
+
+        Map<String, Object> expect = new HashMap<>();
+        expect.put("fullstoryUrl", FS.getCurrentSessionURL());
+        Assert.assertEquals(expect, input);
+    }
+
+    @Test
+    public void getNewPayloadWithFSURL_TrackPayload_ReturnsTrackPayload() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        Map<String, Object> context = new HashMap<>();
+        TrackPayload input = new TrackPayload.Builder().userId("userId").event("event").build();
+        BasePayload output = fullStorySegmentMiddleware.getNewPayloadWithFSURL(input,context);
+
+        Assert.assertEquals(output.type(), BasePayload.Type.track);
+    }
+
+    @Test
+    public void getNewPayloadWithFSURL_TrackPayload_ReturnsTrackPayloadWithFSURL() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        Map<String, Object> context = new HashMap<>();
+        TrackPayload input = new TrackPayload.Builder().userId("userId").event("event").build();
+        TrackPayload output = (TrackPayload) fullStorySegmentMiddleware.getNewPayloadWithFSURL(input,context);
+
+        Properties expect = new Properties();
+        expect.put("fullstoryUrl", FS.getCurrentSessionURL());
+        Assert.assertEquals(output.properties(), expect);
+    }
+
+
+    @Test
+    public void getNewPayloadWithFSURL_ScreenPayload_ReturnsScreenPayload() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        Map<String, Object> context = new HashMap<>();
+        ScreenPayload input = new ScreenPayload.Builder().userId("userId").name("MainActivity").build();
+        BasePayload output = fullStorySegmentMiddleware.getNewPayloadWithFSURL(input,context);
+
+        Assert.assertEquals(output.type(), BasePayload.Type.screen);
+    }
+
+    @Test
+    public void getNewPayloadWithFSURL_ScreenPayload_ReturnsScreenPayloadWithFSURL() {
+        fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
+        Map<String, Object> context = new HashMap<>();
+        ScreenPayload input = new ScreenPayload.Builder().userId("userId").name("MainActivity").build();
+        ScreenPayload output = (ScreenPayload) fullStorySegmentMiddleware.getNewPayloadWithFSURL(input,context);
+
+        Properties expect = new Properties();
+        expect.put("fullstoryUrl", FS.getCurrentSessionURL());
+        Assert.assertEquals(output.properties(), expect);
+    }
+}

--- a/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
+++ b/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
@@ -108,7 +108,7 @@ public class FullStorySegmentMiddlewareTest {
         Map<String, String> userVars = new HashMap<>();
         userVars.put("groupID_str", groupPayload.groupId());
         verifyStatic(FS.class, VerificationModeFactory.times(1));
-        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // IMPORTANT:  Call the static method you want to verify.
         // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.setUserVars(userVars);
     }
@@ -151,7 +151,7 @@ public class FullStorySegmentMiddlewareTest {
         suffixedMap.put("industry_str", "retail");
 
         verifyStatic(FS.class, VerificationModeFactory.times(1));
-        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // IMPORTANT:  Call the static method you want to verify.
         // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.setUserVars(suffixedMap);
     }
@@ -168,7 +168,7 @@ public class FullStorySegmentMiddlewareTest {
         fullStorySegmentMiddleware.intercept(mockChain);
 
         verifyStatic(FS.class, VerificationModeFactory.times(1));
-        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // IMPORTANT:  Call the static method you want to verify.
         // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.identify(identifyPayload.userId(), new HashMap<>());
     }
@@ -201,7 +201,7 @@ public class FullStorySegmentMiddlewareTest {
         fullStorySegmentMiddleware.intercept(mockChain);
 
         verifyStatic(FS.class, VerificationModeFactory.times(1));
-        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // IMPORTANT:  Call the static method you want to verify.
         // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.event("Segment Screen: " + screenPayload.name(), screenPayload.properties());
     }
@@ -236,7 +236,7 @@ public class FullStorySegmentMiddlewareTest {
         fullStorySegmentMiddleware.intercept(mockChain);
 
         verifyStatic(FS.class, VerificationModeFactory.times(0));
-        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // IMPORTANT:  Call the static method you want to verify.
         // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.event(any(), any());
     }
@@ -268,7 +268,7 @@ public class FullStorySegmentMiddlewareTest {
         fullStorySegmentMiddleware.intercept(mockChain);
 
         verifyStatic(FS.class, VerificationModeFactory.times(0));
-        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // IMPORTANT:  Call the static method you want to verify.
         // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.event(any(),any());
     }
@@ -302,7 +302,7 @@ public class FullStorySegmentMiddlewareTest {
         fullStorySegmentMiddleware.intercept(mockChain);
 
         verifyStatic(FS.class, VerificationModeFactory.times(1));
-        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // IMPORTANT:  Call the static method you want to verify.
         // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.event(trackPayload.event(), trackPayload.properties());
     }
@@ -332,7 +332,7 @@ public class FullStorySegmentMiddlewareTest {
         fullStorySegmentMiddleware.intercept(mockChain);
 
         verifyStatic(FS.class, VerificationModeFactory.times(1));
-        // IMPORTANT:  Call the static method you want to verify. Also applies to the tests below
+        // IMPORTANT:  Call the static method you want to verify.
         // see Mokito document here: https://github.com/powermock/powermock/wiki/mockito#a-full-example-for-mocking-stubbing--verifying-static-method
         FS.event(trackPayload.event(), trackPayload.properties());
     }

--- a/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
+++ b/fullstory-segment-middleware/src/test/java/com/fullstorydev/fullstory_segment_middleware/FullStorySegmentMiddlewareTest.java
@@ -170,7 +170,7 @@ public class FullStorySegmentMiddlewareTest {
     }
 
     @Test
-    public void intercept_IdentifykPayloadChain_UserTraits_ChainProceedCalled() {
+    public void intercept_IdentifyPayloadChain_UserTraits_ChainProceedCalled() {
         fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;
 
@@ -220,7 +220,7 @@ public class FullStorySegmentMiddlewareTest {
     }
 
     @Test
-    public void intercept_ScreenPayloadChain_EnableSendScreenAsEvents_FSEventNotCalled() {
+    public void intercept_ScreenPayloadChain_DisableSendScreenAsEvents_FSEventNotCalled() {
         fullStorySegmentMiddleware = new FullStorySegmentMiddleware(mockContext, "SegmentWriteMockKey");
         fullStorySegmentMiddleware.enableSendScreenAsEvents = false;
         fullStorySegmentMiddleware.enableFSSessionURLInEvents = false;


### PR DESCRIPTION
a bunch more test cases:
- Constructor has default values and different options enabled/disabled is behaving properly
- With different types of Segment payload coming in, verify that we are always reaching `proceed` to pass it back to Segment with correct data (with FSURL inserted or not)
- Verified that correct FS APIs are called with expected data and respecting middleware options

code coverage:
![Screen Shot 2020-07-20 at 6 14 01 PM](https://user-images.githubusercontent.com/46504647/87991729-cb2efe00-cab4-11ea-8c7a-2d1923ed7c59.png)
