### PR TITLE
workaround jitpack build error

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -17,7 +17,12 @@ android {
         versionName "1.0"
         multiDexEnabled true
 
-        buildConfigField("String", "SEGMENT_WRITE_KEY", properties['SEGMENT_WRITE_KEY'])
+        // jitpack build fails because of nil SEGMENT_WRITE_KEY
+        if(properties['SEGMENT_WRITE_KEY'] != null) {
+            buildConfigField("String", "SEGMENT_WRITE_KEY", properties['SEGMENT_WRITE_KEY'])
+        } else {
+            buildConfigField("String", "SEGMENT_WRITE_KEY", "")
+        }
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
buildConfigField errors out when there is no local.properties set for "SEGMENT_WRITE_KEY"
This is the case for jitpack build - ideally we will skip `:demo` during the production build, but for now we simply set the key to empty string