### PR TITLE
fixup - bump version to 1.2.2 with demo app excluded

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,12 @@ With FullStory for Mobile Apps, you can retrieve a link to the session replay an
     > To set a custom tag for your Segment instance, use the [`tag` function](https://github.com/segmentio/analytics-android/blob/d263870011fc92e88f16d7ae35a53d8a9883ba7c/analytics/src/main/java/com/segment/analytics/Analytics.java#L1188) when building your Segment client.
 
 3. Your integration is now ready.
+
+#### Local Develop
+The `demo` app is included in the project. By default the demo app is excluded from the build, add the following line and sync gradle to include it.
+
+```
+include.demo=true
+```
+
+You should now see the `demo` module, and should be able to run the demo app against the local version of the middleware and make or apply changes.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ With FullStory for Mobile Apps, you can retrieve a link to the session replay an
       - App level build.gradle:
 
       ```gradle
-      implementation 'com.github.fullstorydev:fullstory-segment-middleware-android:1.2'
+      implementation 'com.github.fullstorydev:fullstory-segment-middleware-android:1.2.2'
       ```
 
     - Alternatively, download the files manually:

--- a/fullstory-segment-middleware/build.gradle
+++ b/fullstory-segment-middleware/build.gradle
@@ -38,7 +38,7 @@ dependencies {
         maven { url "https://maven.fullstory.com" }
     }
 
-    compileOnly 'com.fullstory:instrumentation-full:1.4.0@aar'
+    compileOnly 'com.fullstory:instrumentation-full:1.23.0@aar'
     compileOnly 'com.segment.analytics.android:analytics:4.7.1'
 
     testImplementation 'junit:junit:4.12'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,8 @@
 include ':fullstory-segment-middleware'
-include ':demo'
 rootProject.name = "FullstorySegmentMiddleware"
+
+Properties properties = new Properties()
+properties.load(file('local.properties').newDataInputStream())
+if (properties.getProperty('include.demo')) {
+    include ':demo'
+}


### PR DESCRIPTION
it seems that the side-by-side NDK is breaking `jitpack` builds from my last PR: see [logs here](https://jitpack.io/com/github/fullstorydev/fullstory-segment-middleware-android/1.2.2/build.log)

Historically we've encountered build issues like this when pulling git repo dependencies via `jitpack` (for example smoke testing). The `demo` app isn't and shouldn't be part of the final lib code, so I decided to only include it when we really do want to use it, mostly just for smoke testing or code samples. Open to discussion of course, LMKWDYT.

Now that I've tested this builds find, bump the version to 1.2.2 in README and once landed I will add a release tag.